### PR TITLE
Add persona pronoun extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
-# SillyTavern Pronouns
+# SillyTavern Pronouns Extension
 
-*An Extension allowing you to set pronouns for both characters and personas. The pronouns can be used in macros in any prompt.*
-
-## Concept
-
-This allows for macro usage of pronouns when writing prompts in World Info, the system prompt (TC) or prompt manager (CC) to be more flexible and dynamic with how you write prompts.
+Add persona pronoun management to SillyTavern without touching core. The extension ports the functionality that previously lived in the SillyTavern staging branch pull request [#4542](https://github.com/SillyTavern/SillyTavern/pull/4542), providing a dedicated UI for editing pronouns and new prompt macros that resolve to the active persona's values.
 
 ## Features
 
-- ...
+- Adds a pronoun editor to the Persona Management screen with fields for subjective, objective, possessive determiner, possessive pronoun, and reflexive forms.
+- Includes quick-fill presets for common pronoun sets (She/Her, He/Him, They/Them, It/Its).
+- Stores pronoun data directly on persona descriptors so the values persist with exports/imports and backups.
+- Registers the following macros for use anywhere macros are supported:
+  - `{{pronoun.subjective}}`
+  - `{{pronoun.objective}}`
+  - `{{pronoun.pos_det}}`
+  - `{{pronoun.pos_pro}}`
+  - `{{pronoun.reflexive}}`
 
+## Installation
 
+1. Download or clone this repository.
+2. Copy the `scripts/extensions/third-party/sillytavern-pronouns` folder into your SillyTavern installation at `public/scripts/extensions/third-party/` (create the directory if it does not exist).
+3. In SillyTavern, open **Settings → Extensions**, enable **Persona Pronouns**, and reload if prompted.
+
+The pronoun editor will appear underneath the persona description field once the extension is enabled.
 
 ## Support and Contributions
 
-Contact me on the SillyTavern Discord @Wolfsblvt, or create a GitHub Issue here.
-
-Contributions via PR are always welcome.
+- Discord: `@Wolfsblvt`
+- GitHub Issues and pull requests are welcome.
 
 ## License
 

--- a/scripts/extensions/third-party/sillytavern-pronouns/index.js
+++ b/scripts/extensions/third-party/sillytavern-pronouns/index.js
@@ -1,0 +1,228 @@
+import { eventSource, event_types, saveSettingsDebounced } from "../../../../script.js";
+import { power_user } from "../../../../scripts/power-user.js";
+import * as Personas from "../../../../scripts/personas.js";
+import { MacrosParser } from "../../../../scripts/macros.js";
+import { t } from "../../../../scripts/i18n.js";
+
+const extensionName = "sillytavern-pronouns";
+const extensionFolderPath = `scripts/extensions/third-party/${extensionName}`;
+const defaultPronoun = Object.freeze({
+    subjective: "",
+    objective: "",
+    posDet: "",
+    posPro: "",
+    reflexive: "",
+});
+
+const pronounPresets = {
+    she: { subjective: "she", objective: "her", posDet: "her", posPro: "hers", reflexive: "herself" },
+    he: { subjective: "he", objective: "him", posDet: "his", posPro: "his", reflexive: "himself" },
+    they: { subjective: "they", objective: "them", posDet: "their", posPro: "theirs", reflexive: "themselves" },
+    it: { subjective: "it", objective: "it", posDet: "its", posPro: "its", reflexive: "itself" },
+};
+
+let isUpdating = false;
+let personaObserver;
+let lastPersonaId = null;
+let uiInjected = false;
+
+function getCurrentPersonaId() {
+    return Personas.user_avatar || "";
+}
+
+function ensurePersonaContainer() {
+    power_user.persona_descriptions = power_user.persona_descriptions || {};
+    const personaId = getCurrentPersonaId();
+    if (!personaId) {
+        return null;
+    }
+
+    if (!power_user.persona_descriptions[personaId]) {
+        power_user.persona_descriptions[personaId] = {};
+    }
+
+    const descriptor = power_user.persona_descriptions[personaId];
+    if (!descriptor.pronoun) {
+        descriptor.pronoun = { ...defaultPronoun };
+    } else {
+        descriptor.pronoun = {
+            subjective: descriptor.pronoun.subjective ?? "",
+            objective: descriptor.pronoun.objective ?? "",
+            posDet: descriptor.pronoun.posDet ?? "",
+            posPro: descriptor.pronoun.posPro ?? "",
+            reflexive: descriptor.pronoun.reflexive ?? "",
+        };
+    }
+
+    return descriptor;
+}
+
+function getCurrentPronounValues() {
+    const personaId = getCurrentPersonaId();
+    if (!personaId) {
+        return defaultPronoun;
+    }
+
+    const descriptor = power_user.persona_descriptions?.[personaId];
+    const pronoun = descriptor?.pronoun;
+    return {
+        subjective: pronoun?.subjective ?? "",
+        objective: pronoun?.objective ?? "",
+        posDet: pronoun?.posDet ?? "",
+        posPro: pronoun?.posPro ?? "",
+        reflexive: pronoun?.reflexive ?? "",
+    };
+}
+
+function refreshPronounInputs() {
+    if (!uiInjected) {
+        return;
+    }
+
+    const personaId = getCurrentPersonaId();
+    if (lastPersonaId !== personaId) {
+        lastPersonaId = personaId;
+    }
+
+    const pronouns = getCurrentPronounValues();
+
+    isUpdating = true;
+    $("#persona_pronoun_subjective").val(pronouns.subjective);
+    $("#persona_pronoun_objective").val(pronouns.objective);
+    $("#persona_pronoun_pos_det").val(pronouns.posDet);
+    $("#persona_pronoun_pos_pro").val(pronouns.posPro);
+    $("#persona_pronoun_reflexive").val(pronouns.reflexive);
+    isUpdating = false;
+}
+
+function onPronounInput() {
+    if (isUpdating) {
+        return;
+    }
+
+    const descriptor = ensurePersonaContainer();
+    if (!descriptor) {
+        return;
+    }
+
+    descriptor.pronoun.subjective = String($("#persona_pronoun_subjective").val() ?? "");
+    descriptor.pronoun.objective = String($("#persona_pronoun_objective").val() ?? "");
+    descriptor.pronoun.posDet = String($("#persona_pronoun_pos_det").val() ?? "");
+    descriptor.pronoun.posPro = String($("#persona_pronoun_pos_pro").val() ?? "");
+    descriptor.pronoun.reflexive = String($("#persona_pronoun_reflexive").val() ?? "");
+
+    saveSettingsDebounced();
+}
+
+function onPronounPresetClick(event) {
+    const presetKey = $(event.currentTarget).data("preset");
+    const preset = pronounPresets[presetKey];
+    if (!preset) {
+        return;
+    }
+
+    isUpdating = true;
+    $("#persona_pronoun_subjective").val(preset.subjective);
+    $("#persona_pronoun_objective").val(preset.objective);
+    $("#persona_pronoun_pos_det").val(preset.posDet);
+    $("#persona_pronoun_pos_pro").val(preset.posPro);
+    $("#persona_pronoun_reflexive").val(preset.reflexive);
+    isUpdating = false;
+
+    onPronounInput();
+}
+
+function registerEventListeners() {
+    $(document).on("click", "#persona_pronoun_extension [data-preset]", onPronounPresetClick);
+    $(document).on("input", "#persona_pronoun_extension input", onPronounInput);
+
+    $(document).on("click", "#user_avatar_block .avatar-container", () => {
+        setTimeout(refreshPronounInputs, 0);
+    });
+
+    eventSource.on(event_types.SETTINGS_LOADED_AFTER, () => setTimeout(refreshPronounInputs, 0));
+    eventSource.on(event_types.CHAT_CHANGED, () => setTimeout(refreshPronounInputs, 0));
+    eventSource.on(event_types.SETTINGS_UPDATED, () => setTimeout(refreshPronounInputs, 0));
+    eventSource.on(event_types.SETTINGS_LOADED_AFTER, () => setTimeout(setupPersonaObserver, 0));
+}
+
+function setupPersonaObserver() {
+    const target = document.querySelector("#your_name");
+    if (!target) {
+        return;
+    }
+
+    if (personaObserver) {
+        personaObserver.disconnect();
+    }
+
+    personaObserver = new MutationObserver(() => {
+        refreshPronounInputs();
+    });
+
+    personaObserver.observe(target, { childList: true, subtree: true, characterData: true });
+}
+
+function registerPronounMacros() {
+    const descriptions = {
+        subjective: t`Current persona subjective pronoun`,
+        objective: t`Current persona objective pronoun`,
+        pos_det: t`Current persona possessive determiner`,
+        pos_pro: t`Current persona possessive pronoun`,
+        reflexive: t`Current persona reflexive pronoun`,
+    };
+
+    MacrosParser.registerMacro("pronoun.subjective", () => getCurrentPronounValues().subjective, descriptions.subjective);
+    MacrosParser.registerMacro("pronoun.objective", () => getCurrentPronounValues().objective, descriptions.objective);
+    MacrosParser.registerMacro("pronoun.pos_det", () => getCurrentPronounValues().posDet, descriptions.pos_det);
+    MacrosParser.registerMacro("pronoun.pos_pro", () => getCurrentPronounValues().posPro, descriptions.pos_pro);
+    MacrosParser.registerMacro("pronoun.reflexive", () => getCurrentPronounValues().reflexive, descriptions.reflexive);
+}
+
+async function injectPronounUI() {
+    if (uiInjected || document.getElementById("persona_pronoun_extension")) {
+        uiInjected = true;
+        return;
+    }
+
+    const target = $("#persona_description");
+    if (!target.length) {
+        return;
+    }
+
+    const html = await $.get(`${extensionFolderPath}/persona-pronouns.html`);
+    target.after(html);
+    const container = $("#persona_pronoun_extension");
+    container.find(".persona_pronoun_title").text(t`Pronoun Settings`);
+    const labelTexts = {
+        subjective: t`Subjective ({{pronoun.subjective}}):`,
+        objective: t`Objective ({{pronoun.objective}}):`,
+        pos_det: t`Possessive Determiner ({{pronoun.pos_det}}):`,
+        pos_pro: t`Possessive Pronoun ({{pronoun.pos_pro}}):`,
+        reflexive: t`Reflexive ({{pronoun.reflexive}}):`,
+    };
+    for (const [key, text] of Object.entries(labelTexts)) {
+        container.find(`[data-pronoun-label="${key}"]`).text(text);
+    }
+
+    const presetTexts = {
+        she: t`She/Her`,
+        he: t`He/Him`,
+        they: t`They/Them`,
+        it: t`It/Its`,
+    };
+    for (const [key, text] of Object.entries(presetTexts)) {
+        const button = container.find(`[data-preset="${key}"]`);
+        button.attr("title", t`Set pronouns to ${text}`);
+        container.find(`[data-preset-label="${key}"]`).text(text);
+    }
+    uiInjected = true;
+}
+
+jQuery(async () => {
+    await injectPronounUI();
+    registerEventListeners();
+    setupPersonaObserver();
+    registerPronounMacros();
+    refreshPronounInputs();
+});

--- a/scripts/extensions/third-party/sillytavern-pronouns/manifest.json
+++ b/scripts/extensions/third-party/sillytavern-pronouns/manifest.json
@@ -1,0 +1,11 @@
+{
+    "display_name": "Persona Pronouns",
+    "loading_order": 10,
+    "requires": [],
+    "optional": [],
+    "js": "index.js",
+    "css": "style.css",
+    "author": "SillyTavern Community",
+    "version": "0.1.0",
+    "homePage": "https://github.com/Wolfsblvt/SillyTavern-Pronouns"
+}

--- a/scripts/extensions/third-party/sillytavern-pronouns/persona-pronouns.html
+++ b/scripts/extensions/third-party/sillytavern-pronouns/persona-pronouns.html
@@ -1,0 +1,46 @@
+<div id="persona_pronoun_extension" class="persona_pronoun_settings_container" data-extension="sillytavern-pronouns">
+    <h4 class="persona_pronoun_title"></h4>
+    <div class="persona_pronoun_fields">
+        <div class="flex-container">
+            <div class="flex1">
+                <label for="persona_pronoun_subjective" data-pronoun-label="subjective"></label>
+                <input id="persona_pronoun_subjective" class="text_pole" type="text" placeholder="e.g. she, he, they, it">
+            </div>
+            <div class="flex1">
+                <label for="persona_pronoun_objective" data-pronoun-label="objective"></label>
+                <input id="persona_pronoun_objective" class="text_pole" type="text" placeholder="e.g. her, him, them, it">
+            </div>
+        </div>
+        <div class="flex-container">
+            <div class="flex1">
+                <label for="persona_pronoun_pos_det" data-pronoun-label="pos_det"></label>
+                <input id="persona_pronoun_pos_det" class="text_pole" type="text" placeholder="e.g. her, his, their, its">
+            </div>
+            <div class="flex1">
+                <label for="persona_pronoun_pos_pro" data-pronoun-label="pos_pro"></label>
+                <input id="persona_pronoun_pos_pro" class="text_pole" type="text" placeholder="e.g. hers, his, theirs, its">
+            </div>
+        </div>
+        <div class="flex-container">
+            <div class="flex1">
+                <label for="persona_pronoun_reflexive" data-pronoun-label="reflexive"></label>
+                <input id="persona_pronoun_reflexive" class="text_pole" type="text" placeholder="e.g. herself, himself, themselves, itself">
+            </div>
+            <div class="flex1"></div>
+        </div>
+    </div>
+    <div class="pronoun_preset_buttons flex-container">
+        <div id="pronoun_preset_she" class="menu_button menu_button_icon" data-preset="she" title="">
+            <div data-preset-label="she"></div>
+        </div>
+        <div id="pronoun_preset_he" class="menu_button menu_button_icon" data-preset="he" title="">
+            <div data-preset-label="he"></div>
+        </div>
+        <div id="pronoun_preset_they" class="menu_button menu_button_icon" data-preset="they" title="">
+            <div data-preset-label="they"></div>
+        </div>
+        <div id="pronoun_preset_it" class="menu_button menu_button_icon" data-preset="it" title="">
+            <div data-preset-label="it"></div>
+        </div>
+    </div>
+</div>

--- a/scripts/extensions/third-party/sillytavern-pronouns/style.css
+++ b/scripts/extensions/third-party/sillytavern-pronouns/style.css
@@ -1,0 +1,19 @@
+/* Pronoun settings UI */
+.persona_pronoun_settings_container {
+    margin: 10px 0;
+}
+
+.persona_pronoun_settings_container .flex-container {
+    gap: 10px;
+}
+
+.pronoun_preset_buttons {
+    margin: 15px 0;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.pronoun_preset_buttons .menu_button {
+    min-width: 100px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- add a SillyTavern extension that restores the persona pronoun management UI from the upstream staging PR
- persist pronoun data on persona descriptors, provide quick presets, and register macros for prompt usage
- document installation and available macros in the README

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df61d602708325871a173ed435ca0f