### PR TITLE
Pronouns Extension v2.1.0 — Repository Migration, Cleanup Hook, and Persona Duplication Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SillyTavern Pronouns [Extension]
 
-[![extension version](https://img.shields.io/badge/dynamic/json?color=blue&label=extension%20version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FWolfsblvt%2FSillyTavern-Pronouns%2Fmain%2Fmanifest.json)](https://github.com/Wolfsblvt/SillyTavern-Pronouns/)
-[![release version](https://img.shields.io/github/release/Wolfsblvt/SillyTavern-Pronouns?color=lightblue&label=release)](https://github.com/Wolfsblvt/SillyTavern-Pronouns/releases/latest)
+[![extension version](https://img.shields.io/badge/dynamic/json?color=blue&label=extension%20version&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FSillyTavern%2FSillyTavern-Pronouns%2Fmain%2Fmanifest.json)](https://github.com/SillyTavern/SillyTavern-Pronouns/)
+[![release version](https://img.shields.io/github/release/SillyTavern/SillyTavern-Pronouns?color=lightblue&label=release)](https://github.com/SillyTavern/SillyTavern-Pronouns/releases/latest)
 [![required ST version](https://img.shields.io/badge/required%20ST%20version-1.17.0-darkred?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAABRFBMVEVHcEyEGxubFhafFRWfFRWeFBSaFhaWFRWfFRWfFRWOFhaeFRWeFBSeFBSfFRWfFRWdFRWbFBSfFBSfFBSdFRWeExOfFBSfFRWdFBSfFRWfFRWfGxudFRWeFBSTFRWeFRWeFRWfFRWcFhaeFRWfFRWeFRWfFRWfFRWeFRWeFRWeFRWgFBSgFRWfFRWfFRWgFRX26ur4+Pj9+/ugFBT9/v6fFRWtOzueFRWeFRWgFRX///+fFRX6+/vXo6OfFBSrODj6/PzIenr28PD+/f2gFRX06ur17e3dr6+rMzPTlJS5VVW+ZGT9/v7y39/y6OioMTHx//+1Skrrz8+qMDD7+/v7/Pzq0tLkvb22UVHHe3v4+Pi3WFjIgoL4+PjNjIy5XFyuQEDmzMzZpKThubn8/Py+YWHz8/P8/Pz9//+gFRX////36+tJcu2kAAAAaXRSTlMAARDDqIkMB8qyAzqXUrnQGROErSmd1o41pL4iL2oFTFiTHYt5ccZ1PF1G6ONj2/z1gv1n32CkQz/t7ceYYH+KqdZT5fSoY+XbwLSH1u8elxi8+OmeqJ78nTmbXBds8WlWNc+EwcovuYtEjPKpAAACkklEQVQ4y3VTZXfbQBBcwYlZlmSRLdmWmRpwqGFOw1BmPvf/f+/JeU3ipr0Pp/d2VzszO7cAJfj/oXiAxK5xFEU9TkoSxa1pLejggcayrMVNp2lk26w2wEvg4iUry7IATUGVPG12tlfrYB2iWjmPFJjGAxiqwYT5dyEr3MVkoUWZhgTAF0K+JRQfkyrrvhYoYcTWGVEvT/EpF/PudIAKBRTU18LQYswcR1bNiRxv0JXzDjYRzWsiIcuzKgk0OzglkMDVMW4QDiteXu5VJ7dLMBoYMxPxLV0QUk9zRK6SAEIwX+FEL0hTgRGSW00mXXY6Ce8oaw5UETiWokhqN21z9D3RUDMKH0dXo/Ozs/PRwfqbV5UgnNKodtHmydxwOPf+Mr+HJy87rT8ie5kBoLhXw/HXm5uNzf2N4/Hcxu6B6wAYtZiGxgBryNOdi+Xl70ABqsKT8WsKqr7rpAwe1ABhLCDPjT9sj39cX/88QqTgqRm1Yx1ZZAAWhKlPDElZ9vP28szM+HI9L1ADUbSIg061QlTmc252Z+nTTxer27+e5QW82evmdt0bLItvt7a2vn1ZnhTsloAXF++8pznVsu3T4xlyxi/Wqefj/UyibNFSOZq0oGKdERR/JVzd3Ht3eDhC8dHeqhZVGEcRGD2mwHAxbkEJ2Y4CUCmiapHw8lg2IyZh7BrA2bhPZHCJ6OeUFD+HVZRFYnShj21ip5FEEy4VTS1JbUZQeV71b22KEuOBHZzYZ1mx3WRZ3/X/sU2SFRTbbfIHXYyK9YdPnF+cPMlYiO5jTT33UpKbeadspxPLcqwvTNmvz8tyY2mnR+bAYtxnmHoyjdhbYZguxspkHwKZNum/1pcioYW6MJm3Yf5v+02S+Q13BVQ4NCDLNAAAAABJRU5ErkJggg==)](https://github.com/SillyTavern/SillyTavern/releases/tag/1.17.0)
 
 Pronoun management for SillyTavern personas. Set pronouns per persona and use them as macros anywhere in your prompts. Includes a dedicated editor in Persona Management, quick presets, a text replacer tool, and slash commands.
@@ -16,7 +16,7 @@ Inspired by and partially ported from SillyTavern PR [#4542](https://github.com/
 Install using SillyTavern's extension installer from the URL:
 
 ```txt
-https://github.com/Wolfsblvt/SillyTavern-Pronouns
+https://github.com/SillyTavern/SillyTavern-Pronouns
 ```
 
 ## Features
@@ -82,6 +82,13 @@ Platform compatibility toggles (only enable if you plan to use character cards f
 
 - **WyvernChat: capitalized variants** — Registers `{{pronounSubjectiveCap}}`, `{{pronounObjectiveCap}}`, etc. The lowercase variants and dot-notation are always available without this toggle.
 - **JanitorAI: compatibility macros** — Registers `{{sub}}`, `{{obj}}`, `{{poss}}`, `{{poss_p}}`, `{{ref}}`.
+
+### Cleanup Extension Data
+
+> [!NOTE]
+> This feature requires the **staging** branch of SillyTavern.
+
+All extension settings and saved pronouns can be removed via the extensions list or during uninstall.
 
 ### Platform Compatibility
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import { injectUI, registerEventListeners, refreshPronounInputs } from './src/ui.js';
-import { ensureSettings } from './src/pronouns.js';
+import { injectUI, registerEventListeners as registerUIEventListeners, refreshPronounInputs } from './src/ui.js';
+import { ensureSettings, cleanAllPronounData, registerDataEventListeners } from './src/pronouns.js';
 import { applyMacroSettings, registerPreProcessors } from './src/macros.js';
 import { registerSlashCommands } from './src/slash-commands.js';
 import { event_types, eventSource } from '/script.js';
@@ -25,8 +25,10 @@ export async function init() {
     const version = SillyTavern.getContext().getExtensionManifest?.(EXTENSION_NAME)?.version ?? null;
     ensureSettings(version);
 
+    registerDataEventListeners();
+
     await injectUI();
-    registerEventListeners();
+    registerUIEventListeners();
 
     registerPreProcessors();
     applyMacroSettings();
@@ -39,6 +41,15 @@ export async function init() {
     console.debug(`[${EXTENSION_NAME}] Extension activated`);
 
     initialized = true;
+}
+
+/**
+ * Extension clean hook — called when the extension is uninstalled.
+ */
+export async function clean() {
+    console.debug(`[${EXTENSION_NAME}] Running clean hook...`);
+    await cleanAllPronounData();
+    console.debug(`[${EXTENSION_NAME}] Clean complete.`);
 }
 
 // TODO: This function is needed as long as the experimental macro engine can be off

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
     "version": "2.0.0",
     "homePage": "https://github.com/Wolfsblvt/SillyTavern-Pronouns",
     "hooks": {
-        "activate": "init"
+        "activate": "init",
+        "clean": "clean"
     }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,8 +6,8 @@
     "js": "index.js",
     "css": "style.css",
     "author": "Wolfsblvt",
-    "version": "2.0.0",
-    "homePage": "https://github.com/Wolfsblvt/SillyTavern-Pronouns",
+    "version": "2.1.0",
+    "homePage": "https://github.com/SillyTavern/SillyTavern-Pronouns",
     "hooks": {
         "activate": "init",
         "clean": "clean"

--- a/src/pronouns.js
+++ b/src/pronouns.js
@@ -2,7 +2,7 @@
  * Core pronoun data, persona state management, and settings for the Pronouns extension.
  */
 
-import { saveSettingsDebounced, user_avatar } from '../../../../../script.js';
+import { saveSettingsDebounced, saveSettings, user_avatar, eventSource, event_types } from '../../../../../script.js';
 import { power_user } from '../../../../../scripts/power-user.js';
 import { extension_settings } from '../../../../extensions.js';
 import { EXTENSION_KEY } from '../index.js';
@@ -256,4 +256,51 @@ export function applyPronounPreset(presetKey) {
     const preset = pronounPresets[presetKey];
     if (!preset) return getCurrentPronounValues();
     return setCurrentPronounValues(preset);
+}
+
+/**
+ * Copies the pronoun data from one persona to another.
+ * No-op if the source persona has no pronouns set.
+ * @param {string} sourceAvatarId
+ * @param {string} targetAvatarId
+ */
+export function copyPronounData(sourceAvatarId, targetAvatarId) {
+    const source = power_user.persona_descriptions?.[sourceAvatarId];
+    if (!source?.pronoun) return;
+
+    power_user.persona_descriptions[targetAvatarId] = power_user.persona_descriptions[targetAvatarId] ?? {};
+    power_user.persona_descriptions[targetAvatarId].pronoun = { ...source.pronoun };
+    saveSettingsDebounced();
+}
+
+/**
+ * Registers data-layer event listeners for persona lifecycle events.
+ * Call once during extension initialization.
+ */
+export function registerDataEventListeners() {
+    // Copy pronouns when a persona is duplicated (requires ST core PR #5448)
+    eventSource.on(event_types.PERSONA_CREATED, (/** @type {{ avatarId: string, duplicatedFromAvatarId?: string }} */ data) => {
+        if (data?.duplicatedFromAvatarId) {
+            copyPronounData(data.duplicatedFromAvatarId, data.avatarId);
+        }
+    });
+}
+
+/**
+ * Removes all pronoun data added by this extension:
+ *  - The `pronoun` field from every persona descriptor
+ *  - The extension's own settings block
+ * Uses a direct (non-debounced) save so data is persisted before any page reload.
+ */
+export async function cleanAllPronounData() {
+    if (power_user?.persona_descriptions) {
+        for (const descriptor of Object.values(power_user.persona_descriptions)) {
+            if (descriptor && 'pronoun' in descriptor) {
+                delete descriptor.pronoun;
+            }
+        }
+    }
+
+    delete extension_settings[EXTENSION_KEY];
+    await saveSettings(); // non-debounced as this can be critical (on extension uninstall, it needs to happen right away or settings cleanup will not be saved)
 }

--- a/templates/persona-pronouns.html
+++ b/templates/persona-pronouns.html
@@ -1,5 +1,8 @@
 <div id="pronoun_extension" class="pronoun-settings-container" data-extension="sillytavern-pronouns">
-    <h4 class="pronoun-title" data-i18n="Pronouns">Pronouns</h4>
+    <h4 class="pronoun-title flex-container alignItemsBaseline">
+        <span data-i18n="Pronouns">Pronouns</span>
+        <i class="fa-solid fa-circle-info opacity50p" title="This section is provided by the SillyTavern-Pronouns extension"></i>
+    </h4>
     <div class="pronoun-fields">
         <div class="flex-container">
             <div class="flex1">


### PR DESCRIPTION
This release migrates the Pronouns extension to the SillyTavern organization repository and adds two key quality-of-life features: automatic cleanup on extension uninstall and pronoun copying when duplicating personas.

### What Changed
- **Repository migration** - Updated all GitHub URLs from Wolfsblvt to the SillyTavern organization
- **Extension cleanup hook** - Added `clean()` lifecycle hook to remove all pronoun data on uninstall
- **Persona duplication support** - Automatically copies pronoun data when duplicating personas
- **Version bump** - Incremented to v2.1.0 with updated manifest URLs
- **Documentation updates** - Added cleanup section and updated installation instructions

### Why These Changes
The repository migration ensures long-term maintenance under the official SillyTavern organization. The cleanup hook addresses user feedback about data persistence after uninstall, providing a clean removal option. Persona duplication support improves workflow efficiency by preserving pronoun settings when copying characters.

### How It Works
- **Cleanup hook**: Uses SillyTavern's lifecycle hook system to run `cleanAllPronounData()` on uninstall, removing pronoun fields from all personas and deleting extension settings
- **Persona duplication**: Listens for `PERSONA_CREATED` events and copies pronoun data from source to target persona when `duplicatedFromAvatarId` is present
- **Repository migration**: Updates README badges, installation URLs, and manifest.json homePage to point to the new organization repository

### Impact
- Users can now cleanly uninstall the extension without leaving residual pronoun data
- Duplicating personas preserves pronoun settings, eliminating manual re-entry
- Extension is now officially maintained under the SillyTavern organization
- All documentation and installation instructions point to the new repository location
